### PR TITLE
fix crash AttributeError: Worker instance has no attribute 'error_sleep'

### DIFF
--- a/dwhois/worker.py
+++ b/dwhois/worker.py
@@ -95,7 +95,7 @@ class Worker:
                 print e.message
 
                 time.sleep(error_sleep)
-                error_sleep = min(self.error_sleep*2, self.sleep_max)
+                error_sleep = min(error_sleep*2, self.sleep_max)
 
     def push_results(self, domain, text):
         """


### PR DESCRIPTION
```
File "/usr/lib/python2.7/site-packages/dwhois-0.11-py2.7.egg/EGG-INFO/scripts/dwhois-worker", line 34, in <module>
File "build/bdist.linux-x86_64/egg/dwhois/worker.py", line 98, in queue
AttributeError: Worker instance has no attribute 'error_sleep'
```
